### PR TITLE
Feature/add arm support

### DIFF
--- a/Formula/klog.rb
+++ b/Formula/klog.rb
@@ -1,9 +1,18 @@
 class Klog < Formula
   desc 'Time tracking CLI with plain-text files'
   homepage 'https://github.com/jotaen/klog'
-  url 'https://github.com/jotaen/klog/releases/download/v5.4/klog-mac-intel.zip'
-  sha256 '0b5c2b9fa900f8f1b25511ca6c079272720bfd9667787e25ef518615c568bf13'
   license 'MIT'
+
+  if Hardware::CPU.intel?
+    url 'https://github.com/jotaen/klog/releases/download/v5.4/klog-mac-intel.zip'
+    sha256 '0b5c2b9fa900f8f1b25511ca6c079272720bfd9667787e25ef518615c568bf13'
+  elsif Hardware::CPU.arm?
+    url 'https://github.com/jotaen/klog/releases/download/v5.4/klog-mac-arm.zip'
+    sha256 '27fff0633aa7e1740ae031875c8392a25b15a4c2e0fae728ed38772688777b09'
+  else
+    raise 'unexpected CPU'
+  end
+
   def install
     bin.install 'klog'
   end

--- a/Formula/klog.rb
+++ b/Formula/klog.rb
@@ -1,5 +1,5 @@
 class Klog < Formula
-  desc 'Time tracking CLI with plain-text files'
+  desc 'CLI tool for time tracking in plain-text files'
   homepage 'https://github.com/jotaen/klog'
   license 'MIT'
 

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -6,20 +6,33 @@ sudo apt update && sudo apt install -y curl jq
 
 echo 'Gathering info...'
 
-SHASUM="$(curl -sL https://github.com/jotaen/klog/releases/download/latest/klog-mac-intel.zip | sha256sum | head -c 64)"
-
 VERSION="$(curl --silent https://api.github.com/repos/jotaen/klog/releases/latest | jq -r '.name')"
+URL_INTEL="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-intel.zip"
+URL_ARM="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-arm.zip"
 
-echo "Checksum: ${SHASUM}"
+SHASUM_INTEL="$(curl -sL ${URL_INTEL} | sha256sum | head -c 64)"
+SHASUM_ARM="$(curl -sL ${URL_ARM} | sha256sum | head -c 64)"
+
+echo "Checksum Intel: ${SHASUM_INTEL}"
+echo "Checksum ARM: ${SHASUM_ARM}"
 echo "Version: ${VERSION}"
 
 echo 'Writing formula...'
 echo "class Klog < Formula
   desc 'Time tracking CLI with plain-text files'
   homepage 'https://github.com/jotaen/klog'
-  url 'https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-intel.zip'
-  sha256 '${SHASUM}'
   license 'MIT'
+
+  if Hardware::CPU.intel?
+    url '${URL_INTEL}'
+    sha256 '${SHASUM_INTEL}'
+  elsif Hardware::CPU.arm?
+    url '${URL_ARM}'
+    sha256 '${SHASUM_ARM}'
+  else
+    raise 'unexpected CPU'
+  end
+
   def install
     bin.install 'klog'
   end

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt update && sudo apt install -y curl jq
+sudo apt-get update && sudo apt-get install -y curl jq
 
 echo 'Gathering info...'
 

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-sudo apt-get update && sudo apt-get install -y curl jq
+if command -v jq >/dev/null && command -v curl >/dev/null; then
+  echo "jq and curl found - skipping"
+else
+  sudo apt-get update && sudo apt-get install -y curl jq
+fi
 
 echo 'Gathering info...'
 

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -1,11 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-if command -v jq >/dev/null && command -v curl >/dev/null; then
-  echo "jq and curl found - skipping"
-else
-  sudo apt-get update && sudo apt-get install -y curl jq
+if [[ "$1" == "--install" ]]; then
+  echo 'Installing script dependencies...'
+  apt-get update
+  ! command -v curl >/dev/null && apt-get install -y curl
+  ! command -v jq >/dev/null && apt-get install -y jq
 fi
 
 echo 'Gathering info...'

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -23,7 +23,7 @@ echo "Version: ${VERSION}"
 
 echo 'Writing formula...'
 echo "class Klog < Formula
-  desc 'Time tracking CLI with plain-text files'
+  desc 'CLI tool for time tracking in plain-text files'
   homepage 'https://github.com/jotaen/klog'
   license 'MIT'
 

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -1,27 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
-apt-get update
-apt-get install -y curl unzip jq
-
-TEMPDIR=$(mktemp -d)
-pushd $TEMPDIR
+sudo apt update && sudo apt install -y curl jq
 
 echo 'Gathering info...'
-curl \
-	--remote-name \
-	--location \
-	--silent \
-	https://github.com/jotaen/klog/releases/latest/download/klog-mac-intel.zip
 
-unzip klog-mac-intel.zip
-
-SHASUM="$(sha256sum klog-mac-intel.zip | head -c 64)"
+SHASUM="$(curl -sL https://github.com/jotaen/klog/releases/download/latest/klog-mac-intel.zip | sha256sum | head -c 64)"
 
 VERSION="$(curl --silent https://api.github.com/repos/jotaen/klog/releases/latest | jq -r '.name')"
-
-popd
 
 echo "Checksum: ${SHASUM}"
 echo "Version: ${VERSION}"

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -14,8 +14,8 @@ VERSION="$(curl --silent https://api.github.com/repos/jotaen/klog/releases/lates
 URL_INTEL="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-intel.zip"
 URL_ARM="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-arm.zip"
 
-SHASUM_INTEL="$(curl -sL ${URL_INTEL} | sha256sum | head -c 64)"
-SHASUM_ARM="$(curl -sL ${URL_ARM} | sha256sum | head -c 64)"
+SHASUM_INTEL="$(curl -sL "${URL_INTEL}" | sha256sum | head -c 64)"
+SHASUM_ARM="$(curl -sL "${URL_ARM}" | sha256sum | head -c 64)"
 
 echo "Checksum Intel: ${SHASUM_INTEL}"
 echo "Checksum ARM: ${SHASUM_ARM}"


### PR DESCRIPTION
The current version of the Formula is limited to installing the intel version of the klog binary

While I was at it I added some simplifications of the generator script

This kind of fixes https://github.com/jotaen/homebrew-klog/issues/1, though it is _not_ the canonical way of using bottles. I found the brew documentation not that helpful for beginners and the formula as in this PR works fine.