### PR TITLE
Feature/build via gh action

### DIFF
--- a/.github/generate-formula.sh
+++ b/.github/generate-formula.sh
@@ -45,4 +45,4 @@ echo "class Klog < Formula
   def install
     bin.install 'klog'
   end
-end" > formula/klog.rb
+end" > ./Formula/klog.rb

--- a/.github/generate-formula.sh
+++ b/.github/generate-formula.sh
@@ -10,20 +10,20 @@ if [[ "$1" == "--install" ]]; then
   ! command -v jq >/dev/null && sudo apt-get install -y jq
 fi
 
-CURL_FLAGS="--fail --silent --location --show-error"
+readonly CURL_FLAGS=(--fail --silent --location --show-error)
 
 echo 'Gathering info...'
 
-VERSION="$(curl ${CURL_FLAGS} https://api.github.com/repos/jotaen/klog/releases/latest | jq -e -r '.name')"
+VERSION="$(curl "${CURL_FLAGS[@]}" https://api.github.com/repos/jotaen/klog/releases/latest | jq -e -r '.name')"
 echo "retrieved version: ${VERSION}"
 
 URL_INTEL="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-intel.zip"
 URL_ARM="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-arm.zip"
 
-SHASUM_INTEL="$(curl ${CURL_FLAGS} "${URL_INTEL}" | sha256sum | head -c 64)"
+SHASUM_INTEL="$(curl "${CURL_FLAGS[@]}" "${URL_INTEL}" | sha256sum | head -c 64)"
 echo "retrieved checksum Intel: ${SHASUM_INTEL}"
 
-SHASUM_ARM="$(curl ${CURL_FLAGS} "${URL_ARM}" | sha256sum | head -c 64)"
+SHASUM_ARM="$(curl "${CURL_FLAGS[@]}" "${URL_ARM}" | sha256sum | head -c 64)"
 echo "retrieved checksum ARM: ${SHASUM_ARM}"
 
 echo 'Writing formula...'

--- a/.github/generate-formula.sh
+++ b/.github/generate-formula.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -o errexit
 set -o pipefail
 
 if [[ "$1" == "--install" ]]; then

--- a/.github/workflows/update_formula.yml
+++ b/.github/workflows/update_formula.yml
@@ -1,0 +1,18 @@
+name: Update Formula
+on: [workflow_dispatch]
+jobs:
+  generate_formula:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run script file
+      run: |
+         ./.github/generate-formula.sh --install
+      shell: sh
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: 'updated Formula'
+        add: 'Formula/klog.rb'

--- a/.github/workflows/update_formula.yml
+++ b/.github/workflows/update_formula.yml
@@ -11,7 +11,7 @@ jobs:
          ./.github/generate-formula.sh --install
       shell: sh
     - name: Commit changes
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # Version 9.1.1
       with:
         default_author: github_actions
         message: 'updated Formula'

--- a/.github/workflows/update_formula.yml
+++ b/.github/workflows/update_formula.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Run script file
+    - name: Generate formula
       run: |
          ./.github/generate-formula.sh --install
       shell: sh
@@ -14,5 +14,5 @@ jobs:
       uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # Version 9.1.1
       with:
         default_author: github_actions
-        message: 'updated Formula'
+        message: 'Release latest version'
         add: 'Formula/klog.rb'

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -1,26 +1,30 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 if [[ "$1" == "--install" ]]; then
   echo 'Installing script dependencies...'
-  apt-get update
-  ! command -v curl >/dev/null && apt-get install -y curl
-  ! command -v jq >/dev/null && apt-get install -y jq
+  sudo apt-get update
+  ! command -v curl >/dev/null && sudo apt-get install -y curl
+  ! command -v jq >/dev/null && sudo apt-get install -y jq
 fi
+
+CURL_FLAGS="--fail --silent --location --show-error"
 
 echo 'Gathering info...'
 
-VERSION="$(curl --silent https://api.github.com/repos/jotaen/klog/releases/latest | jq -r '.name')"
+VERSION="$(curl ${CURL_FLAGS} https://api.github.com/repos/jotaen/klog/releases/latest | jq -e -r '.name')"
+echo "retrieved version: ${VERSION}"
+
 URL_INTEL="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-intel.zip"
 URL_ARM="https://github.com/jotaen/klog/releases/download/${VERSION}/klog-mac-arm.zip"
 
-SHASUM_INTEL="$(curl -sL "${URL_INTEL}" | sha256sum | head -c 64)"
-SHASUM_ARM="$(curl -sL "${URL_ARM}" | sha256sum | head -c 64)"
+SHASUM_INTEL="$(curl ${CURL_FLAGS} "${URL_INTEL}" | sha256sum | head -c 64)"
+echo "retrieved checksum Intel: ${SHASUM_INTEL}"
 
-echo "Checksum Intel: ${SHASUM_INTEL}"
-echo "Checksum ARM: ${SHASUM_ARM}"
-echo "Version: ${VERSION}"
+SHASUM_ARM="$(curl ${CURL_FLAGS} "${URL_ARM}" | sha256sum | head -c 64)"
+echo "retrieved checksum ARM: ${SHASUM_ARM}"
 
 echo 'Writing formula...'
 echo "class Klog < Formula

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o pipefail
 
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
 if [[ "$1" == "--install" ]]; then
   echo 'Installing script dependencies...'
   sudo apt-get update
@@ -45,4 +47,4 @@ echo "class Klog < Formula
   def install
     bin.install 'klog'
   end
-end" > ./Formula/klog.rb
+end" > "${THIS_DIR}/Formula/klog.rb"


### PR DESCRIPTION
Tested it in https://github.com/benjaminbauer/homebrew-klog/actions/runs/3980660153. Did not result in a commit, since no changes resulted in running the generator as expected. I tested the workflow with an artificial change to the formula in https://github.com/benjaminbauer/homebrew-klog/actions/runs/3976325272

This PR also incorporates:

1. reverting to use `sudo` for `apt-get`
2. make the generator script fail early. I had several, unexplained, cases where the version was `null`. This would be a hassle, when the action commits that garbage. Failing early makes reasonably sure that does not happen

fixes https://github.com/jotaen/homebrew-klog/issues/3