### PR TITLE
Deprecate tap

### DIFF
--- a/Formula/klog.rb
+++ b/Formula/klog.rb
@@ -13,7 +13,7 @@ class Klog < Formula
     raise 'unexpected CPU'
   end
 
-  deprecate! date: "2024-03-03", because: "The jotaen/klog tap is no longer maintained and does not provide access to the latest klog releases anymore. Please see the call-for-maintainers at https://github.com/jotaen/homebrew-klog/issues/8"
+  deprecate! date: "2024-03-03", because: "The jotaen/klog tap is no longer maintained and does not provide access to the latest klog releases anymore. It will be deleted at some point in the future. Please see the call-for-maintainers at https://github.com/jotaen/homebrew-klog/issues/8"
 
   def install
     bin.install 'klog'

--- a/Formula/klog.rb
+++ b/Formula/klog.rb
@@ -13,9 +13,7 @@ class Klog < Formula
     raise 'unexpected CPU'
   end
 
-  opoo 'The jotaen/klog tap is currently looking for a maintainer.'
-  opoo 'It might otherwise be abandoned. If you’re interested to volunteer,'
-  opoo 'please see https://github.com/jotaen/homebrew-klog/issues/8'
+  deprecate! date: "2024-03-03", because: "The jotaen/klog tap is no longer maintained and does not provide access to the latest klog releases anymore. Please see the call-for-maintainers at https://github.com/jotaen/homebrew-klog/issues/8"
 
   def install
     bin.install 'klog'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Homebrew for klog
 
-> [!IMPORTANT]  
-> **This Homebrew tap is [looking for a maintainer](https://github.com/jotaen/homebrew-klog/issues/8)!**
-
-Install [klog](https://github.com/jotaen/klog) via Homebrew:
-
-```
-brew tap jotaen/klog
-```
+> [!CAUTION]
+> 
+> **This Homebrew tap (`jotaen/klog`) is no longer maintained**, and will be deleted at some point in the future.
+>
+> Please see [the call for maintainers](https://github.com/jotaen/homebrew-klog/issues/8) if you want to volunteer for taking it over.


### PR DESCRIPTION
This tap will be deprecated as of the upcoming v6.3 release of klog (which won’t be available here anymore, though).